### PR TITLE
add Asset type

### DIFF
--- a/voucher-subgraph/package-lock.json
+++ b/voucher-subgraph/package-lock.json
@@ -10,7 +10,8 @@
       "license": "ISC",
       "dependencies": {
         "@graphprotocol/graph-cli": "^0.71.1",
-        "@graphprotocol/graph-ts": "^0.35.1"
+        "@graphprotocol/graph-ts": "^0.35.1",
+        "@iexec/poco": "^5.3.0"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -602,6 +603,46 @@
       "resolved": "https://registry.npmjs.org/long/-/long-4.0.0.tgz",
       "integrity": "sha512-XsP+KhQif4bjX1kbuSiySJFNAehNxgLb6hPRGJ9QsUr8ajHkuXGdrHmFUTUUXhDwVX2R5bY4JNZEwbUiMhV+MA=="
     },
+    "node_modules/@iexec/erlc": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@iexec/erlc/-/erlc-1.0.0.tgz",
+      "integrity": "sha512-DkgdBbTnHuqryWNX+Epi3xcTOwQOuX+gMwVEiLZqHc0rgjIxtzvvmYJ9U8PXaJJNjIr07MHt7BMclEz9qQTIXg==",
+      "dependencies": {
+        "@openzeppelin/contracts": "^3.3.0"
+      }
+    },
+    "node_modules/@iexec/interface": {
+      "version": "3.0.35-8",
+      "resolved": "https://registry.npmjs.org/@iexec/interface/-/interface-3.0.35-8.tgz",
+      "integrity": "sha512-JkO9bpfpTBCOtJz/TEPzFTLlgamv7fll8RUpwC+8P6UWlGGwCe/IvgAeUZzIJ/syXaAhC0KZ7/03BEiee3f8fg=="
+    },
+    "node_modules/@iexec/poco": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/@iexec/poco/-/poco-5.3.0.tgz",
+      "integrity": "sha512-CO2b6Gv0w9dSgUeIHMzkViCG6UYn8MclZzdNI3hiOqgWFvr+YTTwLW/JSPEWu6Xr1wHUTXG9wFcmNgh2oO2sMA==",
+      "dependencies": {
+        "@iexec/erlc": "1.0.0",
+        "@iexec/interface": "3.0.35-8",
+        "@iexec/solidity": "0.1.0-legacy",
+        "@openzeppelin/contracts": "3.3.0",
+        "@uniswap/v2-periphery": "1.1.0-beta.0",
+        "rlc-faucet-contract": "1.0.9"
+      }
+    },
+    "node_modules/@iexec/solidity": {
+      "version": "0.1.0-legacy",
+      "resolved": "https://registry.npmjs.org/@iexec/solidity/-/solidity-0.1.0-legacy.tgz",
+      "integrity": "sha512-q5jsNoyouZ1hFWRFQIfDexDPdcf5fH4Hbfb83aKWYb/WNisyFWZJF1F6gDMLVCXFbzjZRkHhPf2Wkzomwjc6Sw==",
+      "dependencies": {
+        "@openzeppelin/contracts": "3.0.0-rc.0",
+        "solstruct": "0.0.13"
+      }
+    },
+    "node_modules/@iexec/solidity/node_modules/@openzeppelin/contracts": {
+      "version": "3.0.0-rc.0",
+      "resolved": "https://registry.npmjs.org/@openzeppelin/contracts/-/contracts-3.0.0-rc.0.tgz",
+      "integrity": "sha512-Ts7h4/5tNiRN2iiH10Mp+6CgmK/PETDHYIJ/tpUrXgGjWR51T/Dr8kxa41GeHHhmAsuo+CkcuG9L4di6qth/Mw=="
+    },
     "node_modules/@ipld/dag-cbor": {
       "version": "7.0.3",
       "resolved": "https://registry.npmjs.org/@ipld/dag-cbor/-/dag-cbor-7.0.3.tgz",
@@ -912,6 +953,11 @@
         "node": ">=8"
       }
     },
+    "node_modules/@openzeppelin/contracts": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/@openzeppelin/contracts/-/contracts-3.3.0.tgz",
+      "integrity": "sha512-AemZEsQYtUp1WRkcmZm1div5ORfTpLquLaziCIrSagjxyKdmObxuaY1yjQ5SHFMctR8rLwp706NXTbiIRJg7pw=="
+    },
     "node_modules/@peculiar/asn1-schema": {
       "version": "2.3.8",
       "resolved": "https://registry.npmjs.org/@peculiar/asn1-schema/-/asn1-schema-2.3.8.tgz",
@@ -1117,6 +1163,34 @@
       "integrity": "sha512-JQbbmxZTZehdc2iszGKs5oC3NFnjeay7mtAWrdt7qNtAVK0g19muApzAy4bm9byz79xa2ZnO/BOBC2R8RC5Lww==",
       "dependencies": {
         "@types/node": "*"
+      }
+    },
+    "node_modules/@uniswap/lib": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@uniswap/lib/-/lib-1.1.1.tgz",
+      "integrity": "sha512-2yK7sLpKIT91TiS5sewHtOa7YuM8IuBXVl4GZv2jZFys4D2sY7K5vZh6MqD25TPA95Od+0YzCVq6cTF2IKrOmg==",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@uniswap/v2-core": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@uniswap/v2-core/-/v2-core-1.0.0.tgz",
+      "integrity": "sha512-BJiXrBGnN8mti7saW49MXwxDBRFiWemGetE58q8zgfnPPzQKq55ADltEILqOt6VFZ22kVeVKbF8gVd8aY3l7pA==",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@uniswap/v2-periphery": {
+      "version": "1.1.0-beta.0",
+      "resolved": "https://registry.npmjs.org/@uniswap/v2-periphery/-/v2-periphery-1.1.0-beta.0.tgz",
+      "integrity": "sha512-6dkwAMKza8nzqYiXEr2D86dgW3TTavUvCR0w2Tu33bAbM8Ah43LKAzH7oKKPRT5VJQaMi1jtkGs1E8JPor1n5g==",
+      "dependencies": {
+        "@uniswap/lib": "1.1.1",
+        "@uniswap/v2-core": "1.0.0"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/@whatwg-node/events": {
@@ -4594,6 +4668,11 @@
         "inherits": "^2.0.1"
       }
     },
+    "node_modules/rlc-faucet-contract": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/rlc-faucet-contract/-/rlc-faucet-contract-1.0.9.tgz",
+      "integrity": "sha512-eLsDeiXLCqHqYSaIqSJzHxsRjh0qZt7QxG4/n7VGqReQJr+v7ycC3omAmjnwgtSTQvCcRdY03pWmjb0co3Qtgg=="
+    },
     "node_modules/rlp": {
       "version": "2.2.7",
       "resolved": "https://registry.npmjs.org/rlp/-/rlp-2.2.7.tgz",
@@ -4778,6 +4857,11 @@
       "funding": {
         "url": "https://github.com/chalk/slice-ansi?sponsor=1"
       }
+    },
+    "node_modules/solstruct": {
+      "version": "0.0.13",
+      "resolved": "https://registry.npmjs.org/solstruct/-/solstruct-0.0.13.tgz",
+      "integrity": "sha512-gYlF8yj4rB9V0xC5pz+jT8YsewLQkCsf9FDgswg/zyUliKj48Ty/T2XSEYpUFXPa0kVNKcCTd04tJivjcWeRIw=="
     },
     "node_modules/source-map": {
       "version": "0.6.1",

--- a/voucher-subgraph/package.json
+++ b/voucher-subgraph/package.json
@@ -17,6 +17,7 @@
   "license": "ISC",
   "dependencies": {
     "@graphprotocol/graph-cli": "^0.71.1",
-    "@graphprotocol/graph-ts": "^0.35.1"
+    "@graphprotocol/graph-ts": "^0.35.1",
+    "@iexec/poco": "^5.3.0"
   }
 }

--- a/voucher-subgraph/schema.graphql
+++ b/voucher-subgraph/schema.graphql
@@ -3,9 +3,16 @@ type Account @entity {
   voucher: Voucher @derivedFrom(field: "owner")
 }
 
+enum AssetType {
+  app
+  dataset
+  workerpool
+}
+
 type Asset @entity {
   id: ID!
   voucherTypes: [VoucherType!]! @derivedFrom(field: "eligibleAssets")
+  type: AssetType
 }
 
 type VoucherType @entity {

--- a/voucher-subgraph/subgraph.template.yaml
+++ b/voucher-subgraph/subgraph.template.yaml
@@ -24,6 +24,14 @@ dataSources:
       abis:
         - name: VoucherHub
           file: ./abis/VoucherHub.json
+        - name: PoCo
+          file: node_modules/@iexec/poco/build/contracts/IexecInterfaceNative.json
+        - name: AppRegistry
+          file: node_modules/@iexec/poco/build/contracts/AppRegistry.json
+        - name: DatasetRegistry
+          file: node_modules/@iexec/poco/build/contracts/DatasetRegistry.json
+        - name: WorkerpoolRegistry
+          file: node_modules/@iexec/poco/build/contracts/WorkerpoolRegistry.json
       eventHandlers:
         - event: EligibleAssetAdded(indexed uint256,address)
           handler: handleEligibleAssetAdded


### PR DESCRIPTION
Added Asset type, the type `app`, `dataset`, `workerpool` (or null if none of the previous) is checked against the poco registries when the asset is added.

example query: http://localhost:8000/subgraphs/name/bellecour/iexec-voucher/graphql?query=%7B%0A++voucherTypes+%7B%0A++++id%0A++++sponsoredApps%3A+eligibleAssets%28where%3A+%7Btype%3A+app%7D%29+%7B%0A++++++id%0A++++%7D%0A++++sponsoredDatasets%3A+eligibleAssets%28where%3A+%7Btype%3A+dataset%7D%29+%7B%0A++++++id%0A++++%7D%0A++++sponsoredWorkerpools%3A+eligibleAssets%28where%3A+%7Btype%3A+workerpool%7D%29+%7B%0A++++++id%0A++++%7D%0A++%7D%0A%7D

![image](https://github.com/iExecBlockchainComputing/voucher-deployer/assets/26487010/a55a35df-6250-4c6f-b029-2f2106da0b13)
