### PR TITLE
Fix poco upgrade deployement

### DIFF
--- a/PoCo-patch/upgrade.ts
+++ b/PoCo-patch/upgrade.ts
@@ -4,6 +4,7 @@ import {
   ENSIntegrationDelegate__factory,
   ERC1538UpdateDelegate__factory,
   GenericFactory__factory,
+  IexecAccessorsDelegate__factory,
   IexecAccessorsABILegacyDelegate__factory,
   IexecCategoryManagerDelegate__factory,
   IexecERC20Delegate__factory,
@@ -93,6 +94,31 @@ const main = async () => {
   console.log("Deploying modules...");
   const modules = [
     {
+      name: "IexecAccessorsDelegate",
+      abi: IexecAccessorsDelegate__factory.abi,
+      bytecode: IexecAccessorsDelegate__factory.bytecode,
+    },
+    {
+      name: "IexecAccessorsABILegacyDelegate",
+      abi: IexecAccessorsABILegacyDelegate__factory.abi,
+      bytecode: IexecAccessorsABILegacyDelegate__factory.bytecode,
+    },
+    {
+      name: "IexecCategoryManagerDelegate",
+      abi: IexecCategoryManagerDelegate__factory.abi,
+      bytecode: IexecCategoryManagerDelegate__factory.bytecode,
+    },
+    {
+      name: "IexecERC20Delegate",
+      abi: IexecERC20Delegate__factory.abi,
+      bytecode: IexecERC20Delegate__factory.bytecode,
+    },
+    {
+      name: "IexecEscrowNativeDelegate",
+      abi: IexecEscrowNativeDelegate__factory.abi,
+      bytecode: IexecEscrowNativeDelegate__factory.bytecode,
+    },
+    {
       name: "IexecMaintenanceDelegate",
       abi: IexecMaintenanceDelegate__factory.abi,
       bytecode: IexecMaintenanceDelegate__factory.linkBytecode({
@@ -117,39 +143,6 @@ const main = async () => {
       }),
     },
     {
-      name: "IexecAccessorsDelegate",
-      abi: IexecPocoAccessorsDelegate__factory.abi,
-      bytecode: IexecPocoAccessorsDelegate__factory.linkBytecode({
-        ["contracts/libs/IexecLibOrders_v5.sol:IexecLibOrders_v5"]:
-          deploymentOptions.IexecLibOrders_v5,
-      }),
-    },
-    {
-      name: "IexecAccessorsABILegacyDelegate",
-      abi: IexecAccessorsABILegacyDelegate__factory.abi,
-      bytecode: IexecAccessorsABILegacyDelegate__factory.bytecode,
-    },
-    {
-      name: "IexecCategoryManagerDelegate",
-      abi: IexecCategoryManagerDelegate__factory.abi,
-      bytecode: IexecCategoryManagerDelegate__factory.bytecode,
-    },
-    {
-      name: "IexecERC20Delegate",
-      abi: IexecERC20Delegate__factory.abi,
-      bytecode: IexecERC20Delegate__factory.bytecode,
-    },
-    {
-      name: "IexecEscrowNativeDelegate",
-      abi: IexecEscrowNativeDelegate__factory.abi,
-      bytecode: IexecEscrowNativeDelegate__factory.bytecode,
-    },
-    {
-      name: "IexecMaintenanceExtraDelegate",
-      abi: IexecMaintenanceExtraDelegate__factory.abi,
-      bytecode: IexecMaintenanceExtraDelegate__factory.bytecode,
-    },
-    {
       name: "IexecPoco2Delegate",
       abi: IexecPoco2Delegate__factory.abi,
       bytecode: IexecPoco2Delegate__factory.bytecode,
@@ -164,6 +157,21 @@ const main = async () => {
       abi: ENSIntegrationDelegate__factory.abi,
       bytecode: ENSIntegrationDelegate__factory.bytecode,
     },
+    {
+      name: "IexecMaintenanceExtraDelegate",
+      abi: IexecMaintenanceExtraDelegate__factory.abi,
+      bytecode: IexecMaintenanceExtraDelegate__factory.bytecode,
+    },
+    {
+      name: "IexecPocoAccessorsDelegate",
+      abi: IexecPocoAccessorsDelegate__factory.abi,
+      bytecode: IexecPocoAccessorsDelegate__factory.linkBytecode({
+        ["contracts/libs/IexecLibOrders_v5.sol:IexecLibOrders_v5"]:
+          deploymentOptions.IexecLibOrders_v5,
+      }),
+    },
+    // IexecPocoBoostDelegate out of scope
+    // IexecPocoBoostAccessorsDelegate out of scope
   ];
 
   const genericFactoryInstance = GenericFactory__factory.connect(

--- a/PoCo-patch/upgrade.ts
+++ b/PoCo-patch/upgrade.ts
@@ -1,5 +1,6 @@
 import hre, { ethers } from "hardhat";
 import CONFIG from "../config/config.json";
+import { getFunctionSignatures } from "../migrations/utils/getFunctionSignatures";
 import {
   ERC1538Query__factory,
   ERC1538QueryDelegate__factory,
@@ -214,21 +215,6 @@ const main = async () => {
     console.log(`${module.name} deployed at ${moduleAddress}`);
 
     // Link modules into the factory
-    const signatures: string[] = [];
-    const moduleFactory = new ethers.ContractFactory(
-      module.abi,
-      module.bytecode,
-      owner
-    );
-    moduleFactory.interface.fragments.forEach((fragment) => {
-      if (fragment.type === "function") {
-        signatures.push(fragment.format(ethers.utils.FormatTypes.full));
-      }
-    });
-
-    // Join all signatures with semicolons
-    const functionSignatures = signatures.join(";");
-
     const proxy = ERC1538UpdateDelegate__factory.connect(
       IEXEC_HUB_ADDRESS,
       owner
@@ -236,7 +222,7 @@ const main = async () => {
     const tx = await proxy
       .updateContract(
         moduleAddress,
-        functionSignatures,
+        getFunctionSignatures(module.abi),
         "Linking " + module.name
       )
       .catch((e: any) => {

--- a/PoCo-patch/upgrade.ts
+++ b/PoCo-patch/upgrade.ts
@@ -1,6 +1,7 @@
 import hre, { ethers } from "hardhat";
 import CONFIG from "../config/config.json";
 import {
+  ERC1538Query__factory,
   ERC1538QueryDelegate__factory,
   ENSIntegrationDelegate__factory,
   ERC1538UpdateDelegate__factory,
@@ -210,7 +211,7 @@ const main = async () => {
     await genericFactoryInstance
       .createContract(module.bytecode, salt)
       .then((tx) => tx.wait());
-    console.log(`${module.name} deployed`);
+    console.log(`${module.name} deployed at ${moduleAddress}`);
 
     // Link modules into the factory
     const signatures: string[] = [];
@@ -245,6 +246,19 @@ const main = async () => {
     await tx.wait();
 
     console.log(`Link ${module.name} to proxy`);
+  }
+
+  const erc1538QueryInstance = ERC1538Query__factory.connect(
+    IEXEC_HUB_ADDRESS,
+    owner
+  );
+  const functionCount = await erc1538QueryInstance.totalFunctions();
+  console.log(
+    `The deployed ERC1538Proxy now supports ${functionCount} functions:`
+  );
+  for (let i = 0; i < functionCount.toNumber(); i++) {
+    const [method, , contract] = await erc1538QueryInstance.functionByIndex(i);
+    console.log(`[${i}] ${contract} ${method}`);
   }
 };
 

--- a/PoCo-patch/upgrade.ts
+++ b/PoCo-patch/upgrade.ts
@@ -1,6 +1,7 @@
 import hre, { ethers } from "hardhat";
 import CONFIG from "../config/config.json";
 import {
+  ERC1538QueryDelegate__factory,
   ENSIntegrationDelegate__factory,
   ERC1538UpdateDelegate__factory,
   GenericFactory__factory,
@@ -16,7 +17,10 @@ import {
   IexecPoco2Delegate__factory,
   IexecPocoAccessorsDelegate__factory,
   IexecRelayDelegate__factory,
+  IexecPocoBoostDelegate__factory,
+  IexecPocoBoostAccessorsDelegate__factory,
 } from "../typechain";
+
 const genericFactoryAddress =
   require("@amxx/factory/deployments/GenericFactory.json").address;
 
@@ -94,6 +98,11 @@ const main = async () => {
   console.log("Deploying modules...");
   const modules = [
     {
+      name: "ERC1538QueryDelegate",
+      abi: ERC1538QueryDelegate__factory.abi,
+      bytecode: ERC1538QueryDelegate__factory.bytecode,
+    },
+    {
       name: "IexecAccessorsDelegate",
       abi: IexecAccessorsDelegate__factory.abi,
       bytecode: IexecAccessorsDelegate__factory.bytecode,
@@ -170,8 +179,19 @@ const main = async () => {
           deploymentOptions.IexecLibOrders_v5,
       }),
     },
-    // IexecPocoBoostDelegate out of scope
-    // IexecPocoBoostAccessorsDelegate out of scope
+    {
+      name: "IexecPocoBoostDelegate",
+      abi: IexecPocoBoostDelegate__factory.abi,
+      bytecode: IexecPocoBoostDelegate__factory.linkBytecode({
+        ["contracts/libs/IexecLibOrders_v5.sol:IexecLibOrders_v5"]:
+          deploymentOptions.IexecLibOrders_v5,
+      }),
+    },
+    {
+      name: "IexecPocoBoostAccessorsDelegate",
+      abi: IexecPocoBoostAccessorsDelegate__factory.abi,
+      bytecode: IexecPocoBoostAccessorsDelegate__factory.bytecode,
+    },
   ];
 
   const genericFactoryInstance = GenericFactory__factory.connect(


### PR DESCRIPTION
# fix PoCo upgrade deployment

- deploy all modules (iso https://github.com/iExecBlockchainComputing/PoCo/blob/develop/deploy/0_deploy.ts)
- add logs
- fix bad method signatures in proxy upgrade leading to the proxy not being linked to the newly deployed delegates modules