### PR TITLE
Feature/index voucher usages

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -50,7 +50,7 @@ steps:
     commands:
       - date -u -Iseconds | sed 's/+00:00//g' | sed 's/:/-/g' >> .tags
 
-  - name: docker publish latest
+  - name: docker publish
     image: plugins/docker
     pull: always
     settings:

--- a/.drone.yml
+++ b/.drone.yml
@@ -26,12 +26,28 @@ trigger:
     - promote
   target:
     - latest
+    - next
 
 steps:
-  - name: set tags
+  - name: set tag latest
     image: bash
     commands:
       - echo -n "latest," > .tags
+    when:
+      target:
+        - latest
+
+  - name: set tag next
+    image: bash
+    commands:
+      - echo -n "next," > .tags
+    when:
+      target:
+        - next
+
+  - name: set date tag
+    image: bash
+    commands:
       - date -u -Iseconds | sed 's/+00:00//g' | sed 's/:/-/g' >> .tags
 
   - name: docker publish latest

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,6 +16,7 @@ COPY voucher-subgraph voucher-subgraph
 WORKDIR /app/iexec-voucher-contracts
 
 RUN git checkout develop
+RUN git pull
 RUN git log -1 > .git-log
 RUN rm -rf .git
 RUN npm ci
@@ -38,6 +39,7 @@ RUN cat artifacts/contracts/beacon/Voucher.sol/Voucher.json | jq .abi > ./abis/V
 WORKDIR /app/PoCo
 
 RUN git checkout develop
+RUN git pull
 RUN git log -1 > .git-log
 RUN rm -rf .git
 RUN npm ci

--- a/test/docker-compose.yml
+++ b/test/docker-compose.yml
@@ -5,7 +5,7 @@ services:
     restart: "no"
     image: ghcr.io/foundry-rs/foundry:v1.0.0
     entrypoint: anvil
-    command: "--host 0.0.0.0 --port 8545 --block-time 1 --hardfork berlin --fork-url $BELLECOUR_FORK_URL --fork-block-number $BELLECOUR_FORK_BLOCK --chain-id 134 --gas-limit 6700000 --gas-price 0"
+    command: "--host 0.0.0.0 --port 8545 --hardfork berlin --fork-url $BELLECOUR_FORK_URL --fork-block-number $BELLECOUR_FORK_BLOCK --chain-id 134 --gas-limit 6700000 --gas-price 0"
     expose:
       - 8545
     ports:

--- a/test/test-scripts/helpers/addEligibleAsset.js
+++ b/test/test-scripts/helpers/addEligibleAsset.js
@@ -4,7 +4,7 @@ import {
   provider,
   getVoucherManagerWallet,
 } from "./utils.js";
-import { abi } from "../abis/VoucherHub.js";
+import { voucherHubAbi } from "../abis/VoucherHub.js";
 
 export const addEligibleAsset = async ({
   assetAddress = Wallet.createRandom().address,
@@ -14,7 +14,11 @@ export const addEligibleAsset = async ({
     `Adding ${assetAddress} as eligible asset to voucherType ${voucherType}`
   );
   const voucherManagerWallet = await getVoucherManagerWallet();
-  const voucherHubContract = new Contract(VOUCHER_HUB_ADDRESS, abi, provider);
+  const voucherHubContract = new Contract(
+    VOUCHER_HUB_ADDRESS,
+    voucherHubAbi,
+    provider
+  );
   const tx = await voucherHubContract
     .connect(voucherManagerWallet)
     .addEligibleAsset(voucherType, assetAddress);

--- a/test/test-scripts/helpers/createVoucher.js
+++ b/test/test-scripts/helpers/createVoucher.js
@@ -1,4 +1,4 @@
-import { Contract, Wallet } from "ethers";
+import { Contract, Wallet, ZeroAddress } from "ethers";
 import {
   VOUCHER_HUB_ADDRESS,
   provider,
@@ -16,14 +16,26 @@ export const createVoucher = async ({
     `Creating voucher type ${voucherType} for ${ownerAddress} with value ${value}`
   );
 
-  const weiValue = BigInt(value) * 10n ** 9n;
-  const voucherManagerWallet = await getVoucherManagerWallet();
-  await setBalance(voucherManagerWallet.address, weiValue);
   const voucherHubContract = new Contract(
     VOUCHER_HUB_ADDRESS,
     voucherHubAbi,
     provider
   );
+
+  const existingVoucherAddress = await voucherHubContract.getVoucher(
+    ownerAddress
+  );
+
+  if (existingVoucherAddress !== ZeroAddress) {
+    console.log(
+      `${ownerAddress} already owns the voucher ${existingVoucherAddress}, skipping creation`
+    );
+    return;
+  }
+
+  const weiValue = BigInt(value) * 10n ** 9n;
+  const voucherManagerWallet = await getVoucherManagerWallet();
+  await setBalance(voucherManagerWallet.address, weiValue);
 
   const pocoAddress = await voucherHubContract.getIexecPoco();
   const pocoContract = new Contract(

--- a/test/test-scripts/matchOrdersWithVoucher.js
+++ b/test/test-scripts/matchOrdersWithVoucher.js
@@ -11,7 +11,13 @@ import {
 import { createVoucher } from "./helpers/createVoucher.js";
 
 const main = async () => {
-  const { VOUCHER_TYPE_ID, VOUCHER_VALUE } = process.env;
+  const {
+    VOUCHER_TYPE_ID,
+    VOUCHER_VALUE,
+    APP_PRICE,
+    DATASET_PRICE,
+    WORKERPOOL_PRICE,
+  } = process.env;
 
   const { iexec: iexecWorkerpoolOwner, address: workerpoolAddress } =
     await getWorkerpoolAddressAndOwnerWallet();
@@ -42,16 +48,19 @@ const main = async () => {
         .createWorkerpoolorder({
           workerpool: workerpoolAddress,
           category: 0,
+          workerpoolprice: WORKERPOOL_PRICE,
         })
         .then(iexecWorkerpoolOwner.order.signWorkerpoolorder),
       iexecAppOwner.order
         .createApporder({
           app: appAddress,
+          appprice: APP_PRICE,
         })
         .then(iexecAppOwner.order.signApporder),
       iexecDatasetOwner.order
         .createDatasetorder({
           dataset: datasetAddress,
+          datasetprice: DATASET_PRICE,
         })
         .then(iexecDatasetOwner.order.signDatasetorder),
       iexecRequester.order
@@ -60,6 +69,9 @@ const main = async () => {
           dataset: datasetAddress,
           workerpool: workerpoolAddress,
           category: 0,
+          appmaxprice: APP_PRICE,
+          datasetmaxprice: DATASET_PRICE,
+          workerpoolmaxprice: WORKERPOOL_PRICE,
         })
         .then(iexecRequester.order.signRequestorder),
     ]);

--- a/test/test-scripts/matchOrdersWithVoucher.js
+++ b/test/test-scripts/matchOrdersWithVoucher.js
@@ -18,6 +18,7 @@ const main = async () => {
     DATASET_PRICE,
     WORKERPOOL_PRICE,
     NO_DATASET,
+    REQUESTER_PRIVATE_KEY,
   } = process.env;
 
   const useDataset = !NO_DATASET;
@@ -36,7 +37,10 @@ const main = async () => {
     datasetAddress = res.address;
   }
 
-  const requesterWallet = Wallet.createRandom();
+  const requesterWallet = REQUESTER_PRIVATE_KEY
+    ? new Wallet(REQUESTER_PRIVATE_KEY)
+    : Wallet.createRandom();
+
   const iexecRequester = new IExec(
     {
       ethProvider: getSignerFromPrivateKey(RPC_URL, requesterWallet.privateKey),

--- a/voucher-subgraph/schema.graphql
+++ b/voucher-subgraph/schema.graphql
@@ -31,4 +31,19 @@ type Voucher @entity {
   value: BigInt!
   balance: BigInt!
   authorizedAccounts: [Account!]!
+  deals: [Deal!]! @derivedFrom(field: "sponsor")
+}
+
+type Deal @entity {
+  id: ID!
+  timestamp: BigInt!
+  sponsor: Voucher!
+  sponsoredAmount: BigInt!
+  requester: Account!
+  app: Asset!
+  dataset: Asset
+  workerpool: Asset!
+  appprice: BigInt!
+  datasetprice: BigInt!
+  workerpoolprice: BigInt!
 }

--- a/voucher-subgraph/schema.graphql
+++ b/voucher-subgraph/schema.graphql
@@ -3,18 +3,6 @@ type Account @entity {
   voucher: Voucher @derivedFrom(field: "owner")
 }
 
-enum AssetType {
-  app
-  dataset
-  workerpool
-}
-
-type Asset @entity {
-  id: ID!
-  voucherTypes: [VoucherType!]! @derivedFrom(field: "eligibleAssets")
-  type: AssetType
-}
-
 type VoucherType @entity {
   id: ID!
   description: String!
@@ -34,16 +22,45 @@ type Voucher @entity {
   deals: [Deal!]! @derivedFrom(field: "sponsor")
 }
 
+# common interface for all sponsored assets
+interface Asset {
+  id: ID!
+  voucherTypes: [VoucherType!]!
+}
+
+type App implements Asset @entity {
+  id: ID!
+  name: String!
+  usages: [Deal!]! @derivedFrom(field: "app")
+  voucherTypes: [VoucherType!]! @derivedFrom(field: "eligibleAssets")
+}
+
+type Dataset implements Asset @entity {
+  id: ID!
+  name: String!
+  usages: [Deal!]! @derivedFrom(field: "dataset")
+  voucherTypes: [VoucherType!]! @derivedFrom(field: "eligibleAssets")
+}
+
+type Workerpool implements Asset @entity {
+  id: ID!
+  description: String!
+  usages: [Deal!]! @derivedFrom(field: "workerpool")
+  voucherTypes: [VoucherType!]! @derivedFrom(field: "eligibleAssets")
+}
+
+# the Deal entity schema is based on the Deal entity of PoCo-subgraph
 type Deal @entity {
   id: ID!
+  sponsor: Voucher # voucher specific
+  sponsoredAmount: BigInt # voucher specific
   timestamp: BigInt!
-  sponsor: Voucher!
-  sponsoredAmount: BigInt!
   requester: Account!
-  app: Asset!
-  dataset: Asset
-  workerpool: Asset!
-  appprice: BigInt!
-  datasetprice: BigInt!
-  workerpoolprice: BigInt!
+  app: App!
+  dataset: Dataset
+  workerpool: Workerpool!
+  botSize: BigInt!
+  appPrice: BigInt!
+  datasetPrice: BigInt!
+  workerpoolPrice: BigInt!
 }

--- a/voucher-subgraph/src/utils.ts
+++ b/voucher-subgraph/src/utils.ts
@@ -5,17 +5,24 @@ export function loadOrCreateAccount(id: string): Account {
   let account = Account.load(id);
   if (!account) {
     account = new Account(id);
+    account.save();
   }
-  account.save();
   return account;
 }
 
-export function loadOrCreateAsset(id: string): Asset {
+export function loadOrCreateAsset(
+  id: string,
+  type: string | null = null
+): Asset {
   let asset = Asset.load(id);
   if (!asset) {
     asset = new Asset(id);
+    asset.save();
   }
-  asset.save();
+  if (type && !asset.type) {
+    asset.type = type;
+    asset.save();
+  }
   return asset;
 }
 
@@ -26,7 +33,7 @@ export function loadOrCreateVoucherType(id: string): VoucherType {
     voucherType.eligibleAssets = [];
     voucherType.description = "";
     voucherType.duration = new BigInt(0);
+    voucherType.save();
   }
-  voucherType.save();
   return voucherType;
 }

--- a/voucher-subgraph/src/utils.ts
+++ b/voucher-subgraph/src/utils.ts
@@ -1,5 +1,14 @@
-import { BigInt } from "@graphprotocol/graph-ts";
-import { Account, Asset, VoucherType } from "../generated/schema";
+import { Address, BigInt } from "@graphprotocol/graph-ts";
+import {
+  Account,
+  App,
+  Dataset,
+  VoucherType,
+  Workerpool,
+} from "../generated/schema";
+import { App as AppContract } from "../generated/templates/Voucher/App";
+import { Dataset as DatasetContract } from "../generated/templates/Voucher/Dataset";
+import { Workerpool as WorkerpoolContract } from "../generated/templates/Voucher/Workerpool";
 
 export function loadOrCreateAccount(id: string): Account {
   let account = Account.load(id);
@@ -8,22 +17,6 @@ export function loadOrCreateAccount(id: string): Account {
     account.save();
   }
   return account;
-}
-
-export function loadOrCreateAsset(
-  id: string,
-  type: string | null = null
-): Asset {
-  let asset = Asset.load(id);
-  if (!asset) {
-    asset = new Asset(id);
-    asset.save();
-  }
-  if (type && !asset.type) {
-    asset.type = type;
-    asset.save();
-  }
-  return asset;
 }
 
 export function loadOrCreateVoucherType(id: string): VoucherType {
@@ -36,4 +29,37 @@ export function loadOrCreateVoucherType(id: string): VoucherType {
     voucherType.save();
   }
   return voucherType;
+}
+
+export function loadOrCreateApp(address: Address): App {
+  let app = App.load(address.toHex());
+  if (!app) {
+    app = new App(address.toHex());
+    let contract = AppContract.bind(address);
+    app.name = contract.m_appName();
+    app.save();
+  }
+  return app;
+}
+
+export function loadOrCreateDataset(address: Address): Dataset {
+  let dataset = Dataset.load(address.toHex());
+  if (!dataset) {
+    dataset = new Dataset(address.toHex());
+    let contract = DatasetContract.bind(address);
+    dataset.name = contract.m_datasetName();
+    dataset.save();
+  }
+  return dataset;
+}
+
+export function loadOrCreateWorkerpool(address: Address): Workerpool {
+  let workerpool = Workerpool.load(address.toHex());
+  if (!workerpool) {
+    workerpool = new Workerpool(address.toHex());
+    let contract = WorkerpoolContract.bind(address);
+    workerpool.description = contract.m_workerpoolDescription();
+    workerpool.save();
+  }
+  return workerpool;
 }

--- a/voucher-subgraph/src/voucher.ts
+++ b/voucher-subgraph/src/voucher.ts
@@ -1,5 +1,5 @@
-import { PoCo as PoCoContract } from "../generated/VoucherHub/PoCo";
-import { VoucherHub as VoucherHubContract } from "../generated/VoucherHub/VoucherHub";
+import { PoCo as PoCoContract } from "../generated/templates/Voucher/PoCo";
+import { VoucherHub as VoucherHubContract } from "../generated/templates/Voucher/VoucherHub";
 import {
   Voucher as VoucherContract,
   AccountAuthorized,
@@ -7,7 +7,12 @@ import {
   OrdersMatchedWithVoucher,
 } from "../generated/templates/Voucher/Voucher";
 import { Deal, Voucher } from "../generated/schema";
-import { loadOrCreateAccount, loadOrCreateAsset } from "./utils";
+import {
+  loadOrCreateAccount,
+  loadOrCreateApp,
+  loadOrCreateDataset,
+  loadOrCreateWorkerpool,
+} from "./utils";
 import { Address, BigInt } from "@graphprotocol/graph-ts";
 
 export function handleAccountAuthorized(event: AccountAuthorized): void {
@@ -69,28 +74,25 @@ export function handleOrdersMatchedWithVoucher(
 
       let pocoDeal = pocoContract.viewDeal(event.params.dealId);
 
-      let app = loadOrCreateAsset(pocoDeal.app.pointer.toHex(), "app");
+      let app = loadOrCreateApp(pocoDeal.app.pointer);
       deal.app = app.id;
 
       if (pocoDeal.dataset.pointer !== Address.zero()) {
-        let dataset = loadOrCreateAsset(
-          pocoDeal.dataset.pointer.toHex(),
-          "dataset"
-        );
+        let dataset = loadOrCreateDataset(pocoDeal.dataset.pointer);
         deal.dataset = dataset.id;
       }
-      let workerpool = loadOrCreateAsset(
-        pocoDeal.workerpool.pointer.toHex(),
-        "workerpool"
-      );
+
+      let workerpool = loadOrCreateWorkerpool(pocoDeal.workerpool.pointer);
       deal.workerpool = workerpool.id;
 
       let requester = loadOrCreateAccount(pocoDeal.requester.toHex());
       deal.requester = requester.id;
 
-      deal.appprice = pocoDeal.app.price;
-      deal.datasetprice = pocoDeal.dataset.price;
-      deal.workerpoolprice = pocoDeal.workerpool.price;
+      deal.appPrice = pocoDeal.app.price;
+      deal.datasetPrice = pocoDeal.dataset.price;
+      deal.workerpoolPrice = pocoDeal.workerpool.price;
+
+      deal.botSize = pocoDeal.botSize;
 
       deal.save();
     }

--- a/voucher-subgraph/src/voucher.ts
+++ b/voucher-subgraph/src/voucher.ts
@@ -13,7 +13,7 @@ import {
   loadOrCreateDataset,
   loadOrCreateWorkerpool,
 } from "./utils";
-import { Address, BigInt } from "@graphprotocol/graph-ts";
+import { BigInt } from "@graphprotocol/graph-ts";
 
 export function handleAccountAuthorized(event: AccountAuthorized): void {
   let voucherId = event.address.toHex();

--- a/voucher-subgraph/src/voucher.ts
+++ b/voucher-subgraph/src/voucher.ts
@@ -77,7 +77,11 @@ export function handleOrdersMatchedWithVoucher(
       let app = loadOrCreateApp(pocoDeal.app.pointer);
       deal.app = app.id;
 
-      if (pocoDeal.dataset.pointer !== Address.zero()) {
+      // create dataset if a dataset is used
+      if (
+        pocoDeal.dataset.pointer.toHex() != // != because !== does not work
+        "0x0000000000000000000000000000000000000000"
+      ) {
         let dataset = loadOrCreateDataset(pocoDeal.dataset.pointer);
         deal.dataset = dataset.id;
       }

--- a/voucher-subgraph/src/voucherHub.ts
+++ b/voucher-subgraph/src/voucherHub.ts
@@ -16,61 +16,74 @@ import { Voucher, VoucherType } from "../generated/schema";
 import { Voucher as VoucherTemplate } from "../generated/templates";
 import {
   loadOrCreateAccount,
-  loadOrCreateAsset,
+  loadOrCreateApp,
+  loadOrCreateDataset,
   loadOrCreateVoucherType,
+  loadOrCreateWorkerpool,
 } from "./utils";
 
 export function handleEligibleAssetAdded(event: EligibleAssetAdded): void {
   let voucherTypeId = event.params.id.toString();
   let addedAssetAddress = event.params.asset;
-  let addedAssetId = addedAssetAddress.toHex();
 
-  let asset = loadOrCreateAsset(addedAssetId);
-  // check asset type
-  let voucherHubContract = VoucherHub.bind(event.address);
-  let pocoContract = PoCo.bind(voucherHubContract.getIexecPoco());
-  if (
-    AppRegistry.bind(pocoContract.appregistry()).isRegistered(addedAssetAddress)
-  ) {
-    asset.type = "app";
-  } else if (
-    DatasetRegistry.bind(pocoContract.datasetregistry()).isRegistered(
-      addedAssetAddress
-    )
-  ) {
-    asset.type = "dataset";
-  } else if (
-    WorkerpoolRegistry.bind(pocoContract.workerpoolregistry()).isRegistered(
-      addedAssetAddress
-    )
-  ) {
-    asset.type = "workerpool";
-  }
-  asset.save();
-
-  let voucherType = loadOrCreateVoucherType(voucherTypeId);
-  let eligibleAssets = voucherType.eligibleAssets;
-  let existingEntry = eligibleAssets.indexOf(addedAssetId);
-  // add if not already in list
-  if (existingEntry === -1) {
-    eligibleAssets.push(addedAssetId);
-    voucherType.eligibleAssets = eligibleAssets;
-    voucherType.save();
+  let voucherType = VoucherType.load(voucherTypeId);
+  // do not index changes on non voucherType not indexed
+  if (voucherType) {
+    // check asset type
+    let voucherHubContract = VoucherHub.bind(event.address);
+    let pocoContract = PoCo.bind(voucherHubContract.getIexecPoco());
+    let isRegistredAsset = false;
+    if (
+      AppRegistry.bind(pocoContract.appregistry()).isRegistered(
+        addedAssetAddress
+      )
+    ) {
+      loadOrCreateApp(addedAssetAddress);
+      isRegistredAsset = true;
+    } else if (
+      DatasetRegistry.bind(pocoContract.datasetregistry()).isRegistered(
+        addedAssetAddress
+      )
+    ) {
+      loadOrCreateDataset(addedAssetAddress);
+      isRegistredAsset = true;
+    } else if (
+      WorkerpoolRegistry.bind(pocoContract.workerpoolregistry()).isRegistered(
+        addedAssetAddress
+      )
+    ) {
+      loadOrCreateWorkerpool(addedAssetAddress);
+      isRegistredAsset = true;
+    }
+    // index only apps, datasets and workerpools
+    if (isRegistredAsset) {
+      let addedAssetId = addedAssetAddress.toHex();
+      let eligibleAssets = voucherType.eligibleAssets;
+      let existingEntry = eligibleAssets.indexOf(addedAssetId);
+      // add if not already in list
+      if (existingEntry === -1) {
+        eligibleAssets.push(addedAssetId);
+        voucherType.eligibleAssets = eligibleAssets;
+        voucherType.save();
+      }
+    }
   }
 }
 
 export function handleEligibleAssetRemoved(event: EligibleAssetRemoved): void {
   let voucherTypeId = event.params.id.toString();
-  let removedAssetId = event.params.asset.toHex();
-  loadOrCreateAsset(removedAssetId);
-  let voucherType = loadOrCreateVoucherType(voucherTypeId);
-  let eligibleAssets = voucherType.eligibleAssets;
-  let existingEntry = eligibleAssets.indexOf(removedAssetId);
-  // remove if exists
-  if (existingEntry !== -1) {
-    eligibleAssets.splice(existingEntry);
-    voucherType.eligibleAssets = eligibleAssets;
-    voucherType.save();
+  let voucherType = VoucherType.load(voucherTypeId);
+  // do not index changes on non voucherType not indexed
+  if (voucherType) {
+    let removedAssetId = event.params.asset.toHex();
+    let eligibleAssets = voucherType.eligibleAssets;
+    let existingEntry = eligibleAssets.indexOf(removedAssetId);
+    // remove if exists
+    if (existingEntry !== -1) {
+      eligibleAssets.splice(existingEntry);
+      voucherType.eligibleAssets = eligibleAssets;
+      voucherType.save();
+    }
   }
 }
 

--- a/voucher-subgraph/src/voucherHub.ts
+++ b/voucher-subgraph/src/voucherHub.ts
@@ -107,6 +107,7 @@ export function handleVoucherDebited(event: VoucherDebited): void {
   if (voucher) {
     let sponsoredAmount = event.params.sponsoredAmount;
     voucher.balance = voucher.balance.minus(sponsoredAmount);
+    voucher.save();
   }
 }
 

--- a/voucher-subgraph/subgraph.template.yaml
+++ b/voucher-subgraph/subgraph.template.yaml
@@ -63,9 +63,14 @@ templates:
         - Account
         - Voucher
         - VoucherType
+        - Deal
       abis:
         - name: Voucher
           file: ./abis/Voucher.json
+        - name: VoucherHub
+          file: ./abis/VoucherHub.json
+        - name: PoCo
+          file: node_modules/@iexec/poco/build/contracts/IexecInterfaceNative.json
       eventHandlers:
         - event: AccountAuthorized(indexed address)
           handler: handleAccountAuthorized

--- a/voucher-subgraph/subgraph.template.yaml
+++ b/voucher-subgraph/subgraph.template.yaml
@@ -18,9 +18,11 @@ dataSources:
       language: wasm/assemblyscript
       entities:
         - Account
-        - Asset
         - Voucher
         - VoucherType
+        - App
+        - Dataset
+        - Workerpool
       abis:
         - name: VoucherHub
           file: ./abis/VoucherHub.json
@@ -32,6 +34,12 @@ dataSources:
           file: node_modules/@iexec/poco/build/contracts/DatasetRegistry.json
         - name: WorkerpoolRegistry
           file: node_modules/@iexec/poco/build/contracts/WorkerpoolRegistry.json
+        - name: App
+          file: node_modules/@iexec/poco/build/contracts/AppInterface.json
+        - name: Dataset
+          file: node_modules/@iexec/poco/build/contracts/DatasetInterface.json
+        - name: Workerpool
+          file: node_modules/@iexec/poco/build/contracts/WorkerpoolInterface.json
       eventHandlers:
         - event: EligibleAssetAdded(indexed uint256,address)
           handler: handleEligibleAssetAdded
@@ -64,6 +72,9 @@ templates:
         - Voucher
         - VoucherType
         - Deal
+        - App
+        - Dataset
+        - Workerpool
       abis:
         - name: Voucher
           file: ./abis/Voucher.json
@@ -71,6 +82,18 @@ templates:
           file: ./abis/VoucherHub.json
         - name: PoCo
           file: node_modules/@iexec/poco/build/contracts/IexecInterfaceNative.json
+        - name: AppRegistry
+          file: node_modules/@iexec/poco/build/contracts/AppRegistry.json
+        - name: DatasetRegistry
+          file: node_modules/@iexec/poco/build/contracts/DatasetRegistry.json
+        - name: WorkerpoolRegistry
+          file: node_modules/@iexec/poco/build/contracts/WorkerpoolRegistry.json
+        - name: App
+          file: node_modules/@iexec/poco/build/contracts/AppInterface.json
+        - name: Dataset
+          file: node_modules/@iexec/poco/build/contracts/DatasetInterface.json
+        - name: Workerpool
+          file: node_modules/@iexec/poco/build/contracts/WorkerpoolInterface.json
       eventHandlers:
         - event: AccountAuthorized(indexed address)
           handler: handleAccountAuthorized


### PR DESCRIPTION
## Feature

index deals sponsored by a voucher:
- dealid
- timestamp
- sponsored amount
- app
- dataset
- workerpool
- app price
- dataset price
- workerpool price

NB: deals where sponsored amount is 0 are ignored

**example query**

```gql
{
  accounts {
    id
    voucher {
      id
      value
      balance
      deals(orderBy: timestamp, orderDirection: desc) {
        dealid: id
        app {
          address: id
          name
        }
        dataset {
          address: id
          name
        }
        workerpool {
          address: id
          description
        }
        appPrice
        datasetPrice
        workerpoolPrice
        sponsoredAmount
      }
    }
  }
}
```

**example response**

```gql
{
  "data": {
    "accounts": [
      {
        "id": "0x0b2aa7e158c18a611d831aa5baca95f17c21f8ab",
        "voucher": {
          "id": "0xc00d3e1fdb10e9399385a6d18f1e46036cdbfeba",
          "value": "1000",
          "balance": "897",
          "deals": [
            {
              "dealid": "0x1718aaa36f9cdd8a90f4849514f42357a12be56547b25152578c1f2760196866",
              "app": {
                "address": "0x3d6e895652eb3482ee1ba3e5d06f5ee8fa73be24",
                "name": "test app"
              },
              "dataset": {
                "address": "0x2254975d525b71da4ba2994d34786663e0780149",
                "name": "test dataset"
              },
              "workerpool": {
                "address": "0x16c0c6b132ad03dc0b21726f7fc5afff8b615e24",
                "description": "test pool"
              },
              "appPrice": "1",
              "datasetPrice": "100",
              "workerpoolPrice": "2",
              "sponsoredAmount": "103"
            }
          ]
        }
      }
    ]
  }
}
```

## testing

start a fresh environment

```sh
npm run start-test-stack
```
use the test scripts to feed the contract with sponsored deals

```sh
cd test/test-scipts
npm ci
```

```sh
node createVoucherType.js
node addEligibleApp.js
node addEligibleDaatset.js
node addEligibleWorkerPool.js

# set a private-key for the requester
export REQUESTER_PRIVATE_KEY=0xa6784606110bd5696c753a0f71266c419a411883a297ee2b592704d7c67cfcae

# execute some match orders with a voucher
node matchOrdersWithVoucher.js
DATASET_PRICE=100 WORKERPOOL_PRICE=2 APP_PRICE=1 node matchOrdersWithVoucher.js
NO_DATASET=true WORKERPOOL_PRICE=5 APP_PRICE=10 node matchOrdersWithVoucher.js
# ...
```

## :warning:  Breaking change

the `Asset` entity is replaced by `App`, `Dataset` and `Workerpool`
this choice narrows the gap between the PoCo and Voucher subgraphs schemas to increase the mergeability
as a drawback, this requires an implementation change in the iexec sdk (showUserVoucher)

![image](https://github.com/iExecBlockchainComputing/voucher-deployer/assets/26487010/e6bbf70f-9e47-4bf5-a315-052f8a2b8df2)

iexec SDK PR: https://github.com/iExecBlockchainComputing/iexec-sdk/pull/272 