### PR TITLE
skip voucherHub deployment when VOUCHER_HUB_ADDRESS and VOUCHER_HUB_START_BLOCK are set

### DIFF
--- a/PoCo-patch/upgrade.ts
+++ b/PoCo-patch/upgrade.ts
@@ -209,9 +209,17 @@ const main = async () => {
       module.bytecode,
       salt
     );
-    await genericFactoryInstance
-      .createContract(module.bytecode, salt)
-      .then((tx) => tx.wait());
+
+    // avoid repeating deployment (would fail via factory)
+    const addressBytecode = await ethers.provider.getCode(moduleAddress);
+    if (addressBytecode == "0x") {
+      await genericFactoryInstance
+        .createContract(module.bytecode, salt)
+        .then((tx) => tx.wait());
+    } else {
+      console.log("⚠️ module already deployed, skipping deployment ⚠️");
+    }
+
     console.log(`${module.name} deployed at ${moduleAddress}`);
 
     // Link modules into the factory

--- a/README.md
+++ b/README.md
@@ -20,6 +20,8 @@ Environments:
 
 - `RPC_URL`: `bellecour-fork` RPC url
 - `FORCE_POCO_UPGRADE`: boolean set it to `true` to force the PoCo upgrade, use this to test next PoCo version (default `false`)
+- `VOUCHER_HUB_ADDRESS`: address of an already deployed `VoucherHub`, if set along with `VOUCHER_HUB_START_BLOCK` skips `VoucherHub` deployment (default unset)
+- `VOUCHER_HUB_START_BLOCK`: number of the block to start indexing `VoucherHub`, if set along with `VOUCHER_HUB_ADDRESS` skips `VoucherHub` deployment (default unset)
 - `SKIP_SUBGRAPH`: boolean set it to `true` to disable the subgraph deployment (default `false`)
 - `GRAPHNODE_URL`: `graphnode` admin url
 - `IPFS_URL`: `ipfs` admin url
@@ -35,10 +37,12 @@ docker run --rm \
 
 Output:
 
-- `iexec-voucher-contracts.git-log`: git logs iexec-voucher-contracts
-- `PoCo.git-log`: git logs PoCo
-- `VoucherHub.address`: address of the deployed VoucherHub contract
-- `VoucherHub.block`: block number of VoucherHub contract deployment
+- when `FORCE_POCO_UPGRADE` is true (deploy PoCo upgrade)
+  - `PoCo.git-log`: git logs PoCo
+- when `VOUCHER_HUB_ADDRESS` or `VOUCHER_HUB_START_BLOCK` is not set (deploy VoucherHub)
+  - `iexec-voucher-contracts.git-log`: git logs iexec-voucher-contracts
+  - `VoucherHub.address`: address of the deployed VoucherHub contract
+  - `VoucherHub.block`: block number of VoucherHub contract deployment
 
 ## Test
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -3,16 +3,18 @@ mkdir /app/out
 
 # deploy voucher
 echo -e "\n#####################################\n# deploying iexec-voucher-contracts #\n#####################################\n"
-
-cd /app/iexec-voucher-contracts
-cat .git-log
-cp .git-log /app/out/iexec-voucher-contracts.git-log
-npx hardhat run deploy/deploy.ts --network bellecour-fork || exit 1
-
-cp /app/iexec-voucher-contracts/VoucherHub.address /app/out/
-cp /app/iexec-voucher-contracts/VoucherHub.block /app/out/
-
-cp -r /app/iexec-voucher-contracts/abis/ /app/out/
+if [ "$VOUCHER_HUB_ADDRESS" != "" ] && [ "$VOUCHER_HUB_START_BLOCK" != "" ]
+then
+    echo -e "VOUCHER_HUB_ADDRESS is set to $VOUCHER_HUB_ADDRESS\nVOUCHER_HUB_START_BLOCK is set to $VOUCHER_HUB_START_BLOCK\n  => skiping iexec-voucher-contracts deployment"
+else
+    cd /app/iexec-voucher-contracts
+    cat .git-log
+    cp .git-log /app/out/iexec-voucher-contracts.git-log
+    npx hardhat run deploy/deploy.ts --network bellecour-fork || exit 1
+    cp /app/iexec-voucher-contracts/VoucherHub.address /app/out/
+    cp /app/iexec-voucher-contracts/VoucherHub.block /app/out/
+    cp -r /app/iexec-voucher-contracts/abis/ /app/out/
+fi
 
 # upgrade poco
 echo -e "\n##########################\n# deploying PoCo upgrade #\n##########################\n"
@@ -33,8 +35,8 @@ then
     echo -e "SKIP_SUBGRAPH == true\n  => skiping subgraph deployment"
 else
     cd /app/voucher-subgraph
-    export VOUCHER_HUB_ADDRESS=$(cat /app/out/VoucherHub.address)
-    export VOUCHER_HUB_START_BLOCK=$(cat /app/out/VoucherHub.block)
+    export VOUCHER_HUB_ADDRESS=$(cat /app/out/VoucherHub.address || echo $VOUCHER_HUB_ADDRESS)
+    export VOUCHER_HUB_START_BLOCK=$(cat /app/out/VoucherHub.block || echo $VOUCHER_HUB_START_BLOCK)
     npm run codegen || exit 1
     npm run create || exit 1
     npm run deploy || exit 1

--- a/package.json
+++ b/package.json
@@ -3,8 +3,12 @@
   "type": "module",
   "description": "This project allow deploying iExec voucher related contracts and associated subgraph on a bellecour forked test chain (anvil).",
   "scripts": {
+    "build": "docker build . --no-cache -t voucher-deployer",
     "test": "npm run start-test-stack && docker logs -f test-voucher-deployer-1",
+    "test-force-poco-upgrade": "FORCE_POCO_UPGRADE=true npm run start-test-stack && docker logs -f test-voucher-deployer-1",
+    "test-skip-voucher": "VOUCHER_HUB_ADDRESS=0x3137B6DF4f36D338b82260eDBB2E7bab034AFEda VOUCHER_HUB_START_BLOCK=30306387 npm run start-test-stack && docker logs -f test-voucher-deployer-1",
+    "test-skip-subgraph": "SKIP_SUBGRAPH=true npm run start-test-stack && docker logs -f test-voucher-deployer-1",
     "stop-test-stack": "cd test && docker compose down --remove-orphans --volumes",
-    "start-test-stack": "cd test && npm run stop-test-stack && node prepare-test-env.js && docker compose build --no-cache && docker compose up -d"
+    "start-test-stack": "cd test && npm run stop-test-stack && node prepare-test-env.js && docker compose build && docker compose up -d"
   }
 }

--- a/test/docker-compose.yml
+++ b/test/docker-compose.yml
@@ -93,8 +93,10 @@ services:
       RPC_URL: http://bellecour-fork:8545
       GRAPHNODE_URL: http://graphnode:8020
       IPFS_URL: http://ipfs:5001
-      SKIP_SUBGRAPH: $SKIP_SUBGRAPH
       FORCE_POCO_UPGRADE: $FORCE_POCO_UPGRADE
+      VOUCHER_HUB_ADDRESS: $VOUCHER_HUB_ADDRESS
+      VOUCHER_HUB_START_BLOCK: $VOUCHER_HUB_START_BLOCK
+      SKIP_SUBGRAPH: $SKIP_SUBGRAPH
     volumes:
       - ./out:/app/out
     depends_on:


### PR DESCRIPTION
setting `VOUCHER_HUB_ADDRESS` and `VOUCHER_HUB_START_BLOCK` will skip the `VoucherHub` deployment and use the provided value to configure the subgraph